### PR TITLE
DBの永続化対応と生成されるDB系ファイルのgitignore対象追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres:9.6-alpine
     restart: always
     volumes:
-      - ./containers/db:/docker-entrypoint-initdb.d
+      - ./data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: pass
       POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --locale=C"


### PR DESCRIPTION
## 要件・仕様
DBのデータを永続化させる

## 処理概要
- docker-composeのDBデータの持ち方に関する記述の修正
- カレントディレクトリにDBデータを持つようにしたため、出力されたファイル類をGit管理対象外に指定

## 特記
プロジェクトフォルダ直下にDBデータを保存するようにしてしまっていますので、別の場所が良ければ変更して下さい。

## 動作確認観点
なし

## 参考
なし