### PR TITLE
ステップ19: ページネーションを追加しよう

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'rails-i18n'
 
 gem 'enum_help'
+
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,18 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -238,6 +250,7 @@ DEPENDENCIES
   enum_help
   factory_bot_rails
   jbuilder (~> 2.5)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   pg (~> 1.1.4)
   puma (~> 3.11)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -58,7 +58,8 @@ class TasksController < ApplicationController
   # タスクをタイトルで検索する
   # @return[Object] タイトル検索の結果
   def title_search
-    @tasks = params[:title].present? ? Task.where('title LIKE ?', "%#{params[:title]}%").page(params[:page]).per(5) : Task.page(params[:page]).per(5)
+    @tasks = params[:title].present? ? Task.where('title LIKE ?', "%#{params[:title]}%") : Task.all
+    @tasks = @tasks.page(params[:page]).per(5)
   end
 
   # タスクをステータスで検索する

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -58,7 +58,7 @@ class TasksController < ApplicationController
   # タスクをタイトルで検索する
   # @return[Object] タイトル検索の結果
   def title_search
-    @tasks = params[:title].present? ? Task.where('title LIKE ?', "%#{params[:title]}%") : Task.all
+    @tasks = params[:title].present? ? Task.where('title LIKE ?', "%#{params[:title]}%").page(params[:page]).per(5) : Task.page(params[:page]).per(5)
   end
 
   # タスクをステータスで検索する

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -40,4 +40,4 @@
       <% end %>
    </tbody>
 </table>
-
+<%= paginate @tasks %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,11 @@
 ja:
+  views:
+    pagination:
+      first: "最初"
+      last: "最後"
+      previous: "前"
+      next: "次"
+      truncate: "..."
   enums:
     task:
       status:


### PR DESCRIPTION
## 要件・仕様
- KaminariというGemを使って一覧画面にページネーションを追加してみましょう
## 処理概要
- Gemfileにgem 'kaminari'を記載し、bundle installを行いました。
- tasks_controller.rbのtitle_searchメソッドに`page(params[:page]).per(5) `を追加しました。
- index.html.erbに`<%= paginate @tasks %>`を追加しました。

## 特記
- ~~Kaminariをカスタマイズしようと思いましたが、次のステップでBootstrapを導入しますので、その際に同時にカスタマイズしようと考えています。~~
→Kaminariを日本語化し、デザインは次ステップで行います。

- 一覧画面に表示されるタスク数は最大５個で、それ以上は次ページにページネーションしています。

## 動作確認観点
### タスク一覧画面１ページ目
![タスク一覧画面](https://user-images.githubusercontent.com/46443484/102050283-e0227a00-3e25-11eb-9136-c445cce52aea.png)

### タスク一覧画面６ページ目

![タスク一覧の６ページ目](https://user-images.githubusercontent.com/46443484/102050394-16f89000-3e26-11eb-934a-ec3e8b6c3ead.png)


### 検索結果の１ページ目
![検索結果の１ページ目](https://user-images.githubusercontent.com/46443484/102050458-3b546c80-3e26-11eb-975d-6ac1bb167ad4.png)



### 検索結果の６ページ目

![検索結果の６ページ目](https://user-images.githubusercontent.com/46443484/102050501-54f5b400-3e26-11eb-8562-a4a7274c4782.png)



## 参考
https://qiita.com/you8/items/df68aaee3010e282d1ae
https://qiita.com/residenti/items/1ae1e5ceb59c0729c0b9